### PR TITLE
Resolve forgotten changes regarding license and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ Cloning is a pretty standard task, but if you need a hand, you can find the comm
 git clone https://github.com/nizarmah/urban-tree.git
 ```
 
+Make sure to cd into the cloned project after.
+
+```sh
+cd urban-tree
+```
+
 ### Specify Node Version
 
 Initially, make sure you have [Node Version Manager](https://github.com/nvm-sh/nvm) installed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "urban-tree",
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "GPL-3.0",
       "dependencies": {
         "express": "^4.17.3"
       },


### PR DESCRIPTION
### Description

Pull request #1 had two missing things which were overlooked during the review, unfortunately:
* `package.json` was updated to use the `GPL-3.0` license, but `package-lock.json` wasn't
* the documentation didn't mention that the user should change directory to the cloned repository

Accordingly, this pull requests addresses these issues.