### PR TITLE
Snapshot directories by traversing root nodes recursively

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,4 @@ In case you'd like to learn more about the scripts available, you can find them 
 |`start`|starts the node js server (without building)|
 |`deploy`|runs the `build` script followed by the `start` script|
 |`lint`|runs eslint against the typescript code|
+|`debug`|runs the `deploy` script in debugging mode|

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "rebuild": "npm run clean && npm run build",
     "start": "node dist/app.js",
     "deploy": "npm run build && npm run start",
+    "debug": "DEBUG=:* npm run deploy",
     "lint": "eslint . --ext .ts",
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,10 +1,24 @@
 import express from 'express';
 
+import { FileTreeNode } from './models/fileTreeNode';
+
 const app = express();
 const port = 3000;
 
+const rootDirectoryNodes: FileTreeNode[] = [];
+
+const queuedDirectories = process.argv.splice(2);
+console.debug(`queued directories: ${queuedDirectories}`);
+
+queuedDirectories.forEach(
+    directoryPath => rootDirectoryNodes.push(new FileTreeNode(directoryPath)));
+
 app.get('/', (req, res) => {
-    res.send("Hello World!");
+    res.json(
+        {
+            directories: rootDirectoryNodes,
+        }
+    );
 });
 
 app.listen(port, () => {

--- a/src/models/fileTreeNode.ts
+++ b/src/models/fileTreeNode.ts
@@ -1,0 +1,31 @@
+import fs from 'fs';
+import path from 'path';
+
+export class FileTreeNode {
+    filePath = "";
+    baseName = "";
+
+    isDirectory = false;
+    child_nodes: FileTreeNode[] = [];
+
+    constructor(filePath: string) {
+        this.filePath = filePath;
+        this.baseName = path.parse(filePath).base;
+
+        // ensure file exists before checking if it is a directory
+        // otherwise an error is thrown
+        if (fs.existsSync(this.filePath) && 
+                fs.lstatSync(this.filePath).isDirectory()) {
+            this.isDirectory = true;
+            this.collectChildNodes();
+        }
+    }
+
+    private collectChildNodes() {
+        fs.readdirSync(this.filePath).forEach(childFileName => {
+            const childFilePath = path.join(this.filePath, childFileName);
+
+            this.child_nodes.push(new FileTreeNode(childFilePath));
+        });
+    }
+}


### PR DESCRIPTION
### Description

This pull request implements the ability to "snapshot" directories. 

The node program records the tree structure (files and sub-directories) of each directory passed as a parameter.

The directories passed as parameters are considered root nodes, and then the program recursively traverses each node and defines its children, which traverses each child and defines the child's children, and so on...

By doing so, we record the entire tree, from each directory. 

We store that information in memory, as cache. This allows us to instantly return the entire tree, instead of computing it again and again.

### Testing

* Set up the server
* Run the server with the following command with the directories you'd like included

```
npm run debug ~/Documents ~/Downloads ...
```

* Navigate to `http://localhost:3000` and make sure the JSON data matches your file directories

### Notes

This change can be optimized in the future. 

Imagine passing two directories as parameters, one is `~/A` and the other is `~/A/B`.

At the moment, the program traverse both `~/A` and `~/A/B`. However, we're traversing `~/A/B` twice.

This can be optimized by using memoization. That way we wouldn't have to re-traverse `~/A/B`. Instead, we can just point towards that Node.