### PR TITLE
Fix client not adding directory modification recursively

### DIFF
--- a/client/src/components/FileExplorerNode.tsx
+++ b/client/src/components/FileExplorerNode.tsx
@@ -20,16 +20,16 @@ function FileExplorerNode(props: FileExplorerNodeProps) {
 
     const nodePath = props.nodePath;
     const nodeName = props.nodeName;
-    const hasChildren = TreeMemo.hasChildren(nodePath);
+    const isDirectory = TreeMemo.isDirectory(nodePath);
 
     return (
         <>
             <li key={[props.nodePath, "-", "node"].join()}
-                    className={hasChildren ? collapsed ? 
+                    className={isDirectory ? collapsed ? 
                         "FileNode CollapsedFileNode" : "FileNode CollapsableFileNode" : "FileNode"}>
-                <label className="FileNodeLabel" onClick={hasChildren ? toggle : void 0}>{props.nodeName}</label>
+                <label className="FileNodeLabel" onClick={isDirectory ? toggle : void 0}>{props.nodeName}</label>
                 {
-                    hasChildren && !collapsed &&
+                    isDirectory && !collapsed &&
                         <FileExplorerTree key={[props.nodePath, "-", "subtree"].join()}
                             treePath={props.nodePath} />
                 }

--- a/client/src/components/FileExplorerTree.tsx
+++ b/client/src/components/FileExplorerTree.tsx
@@ -1,8 +1,5 @@
 import { useTreeMemo } from "../hooks/useTreeMemo";
-import { 
-    getChildrenNodesAsArray,    
-    FileTreeNode,
-} from "../utils/fileTree";
+import { FileTreeNode } from "../utils/fileTree";
 
 import FileExplorerNode from "./FileExplorerNode";
 
@@ -13,8 +10,7 @@ interface FileExplorerTreeProps {
 }
 
 function FileExplorerTree(props: FileExplorerTreeProps) {
-    const childNodes = useTreeMemo(props.treePath || "")
-        .filter((node: FileTreeNode) => node && node.filePath.length > 0);
+    const childNodes = useTreeMemo(props.treePath || "");
     
     return (
         <ul className="FileTree" key={[props.treePath, "-", "tree"].join()}>

--- a/client/src/hooks/useTreeMemo.ts
+++ b/client/src/hooks/useTreeMemo.ts
@@ -1,14 +1,15 @@
 import { useState, useEffect } from "react";
 import { useTreeStream } from './useTreeStream';
 
-import { FileTreeNode, FileTreeModification } from '../utils/fileTree';
+import { FileTreeNode } from '../utils/fileTree';
 import { TreeMemo } from '../utils/treeMemo';
 
 export function useTreeMemo(requestedPath: string) {
     const [treeBranch, setTreeBranch] = useState<FileTreeNode[]>(
-        TreeMemo.get(requestedPath));
-    const updateTreeBranch = () => setTreeBranch(TreeMemo.get(requestedPath));
-
+        TreeMemo.getChildren(requestedPath));
+    const updateTreeBranch = () => setTreeBranch(
+        TreeMemo.getChildren(requestedPath));
+    
     useTreeStream((event: Event) => updateTreeBranch());
 
     // clean the state after unmounting

--- a/client/src/hooks/useTreeStream.ts
+++ b/client/src/hooks/useTreeStream.ts
@@ -15,9 +15,8 @@ export function useTreeStream(eventHandler: EventSourceCallback) {
             eventSource = new EventSource(SSE_ENDPOINT_URL);
 
             eventSource.addEventListener('update', (event) => {
-                const parsedData: Map<string, FileTreeNode> = JSON.parse(event.data);
-
-                TreeMemo.update(new FileTreeNode(parsedData));
+                TreeMemo.update(
+                    new FileTreeNode('', '', true, JSON.parse(event.data)));
             });
 
             eventSource.addEventListener('modify', (event) => {
@@ -28,7 +27,8 @@ export function useTreeStream(eventHandler: EventSourceCallback) {
                 const node = parsedData.node;
                 
                 if (action.startsWith('add')) {
-                    TreeMemo.add(actionPath, JSON.parse(node));
+                    TreeMemo.add(actionPath,
+                        FileTreeNode.fromObject(JSON.parse(node)));
                 } else if (action.startsWith('unlink')) {
                     TreeMemo.unlink(actionPath);
                 }

--- a/client/src/utils/fileTree.ts
+++ b/client/src/utils/fileTree.ts
@@ -5,10 +5,36 @@ export class FileTreeNode {
     isDirectory = false;
     childNodes = new Map<string, FileTreeNode>();
 
-    constructor(childNodes?: Map<string, FileTreeNode>) {
+    constructor(
+        filePath: string,
+        baseName: string,
+        isDirectory: boolean,
+        childNodes?: Map<string, FileTreeNode>,
+    ) {
+        this.filePath = filePath;
+        this.baseName = baseName;
+        this.isDirectory = isDirectory;
+
         if (childNodes) {
-            this.childNodes = childNodes;
+            Object.values(childNodes).forEach((childObject) => {
+                const node: FileTreeNode = FileTreeNode.fromObject(childObject);
+                
+                this.childNodes.set(node.filePath, node);
+            });
         }
+    }
+
+    getChildNodesAsArray(): FileTreeNode[] {
+        return Array.from(this.childNodes.values());
+    }
+
+    static fromObject(nodeObject: FileTreeNode) {
+        return new FileTreeNode(
+            nodeObject.filePath,
+            nodeObject.baseName,
+            nodeObject.isDirectory,
+            nodeObject.childNodes,
+        );
     }
 }
 
@@ -16,8 +42,4 @@ export class FileTreeModification {
     action = ''
     path = ''
     node = ''
-}
-
-export function getChildrenNodesAsArray(node: FileTreeNode): FileTreeNode[] {
-    return Object.values(node.childNodes);
 }


### PR DESCRIPTION
### Description 

The previous approach wasn't recursively adding the directory. It was only adding the directory as a file, and not adding all the directories inside it. This change fixes that by recursively preparing the child nodes and adding the parent path to the memo.

### Testing

* Run the previous version and try to rename a directory and adding a directory
* Do that again using this branch and make sure things work